### PR TITLE
Use traditional Vencord naming standards.

### DIFF
--- a/src/plugins/becomeCatgirl/index.tsx
+++ b/src/plugins/becomeCatgirl/index.tsx
@@ -76,7 +76,7 @@ const CatgirlMessageToggle: ChatBarButton = ({ isMainChat }) => {
 };
 
 export default definePlugin({
-    name: "Become Catgirl",
+    name: "BecomeCatgirl",
     authors: [(Devs.Tolgchu ?? { name: "✨Tolgchu✨", id: 329671025312923648n })],
     description: "Turns your messages into catgirl messages.",
     dependencies: ["MessageEventsAPI", "ChatInputButtonAPI"],

--- a/src/plugins/talkInReverse/index.tsx
+++ b/src/plugins/talkInReverse/index.tsx
@@ -55,7 +55,7 @@ const ReverseMessageToggle: ChatBarButton = ({ isMainChat }) => {
 };
 
 export default definePlugin({
-    name: "Talk In Reverse",
+    name: "TalkInReverse",
     authors: [(Devs.Tolgchu ?? { name: "✨Tolgchu✨", id: 329671025312923648n })],
     description: "Reverses the message content before sending it.",
     dependencies: ["MessageEventsAPI", "ChatInputButtonAPI"],


### PR DESCRIPTION
Plugins in Vencord don't have any spaces in their name.